### PR TITLE
Docs: remove unstyled link examples

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -166,28 +166,16 @@ const myHandler = (event) => {
                     <a href="javascript: false" class="link link-green">Green link</a>
                 </div>
                 <div class="p-2">
-                    <a href="javascript: false" class="link link-green-secondary">Green Secondary link</a>
-                </div>
-                <div class="p-2">
                     <a href="javascript: false" class="link link-blue">Blue link</a>
                 </div>
                 <div class="p-2">
-                    <a href="javascript: false" class="link link-blue-secondary">Blue Secondary link</a>
-                </div>
-                <div class="p-2">
                     <a href="javascript: false" class="link link-orange">Orange link</a>
-                </div>
-                <div class="p-2">
-                    <a href="javascript: false" class="link link-orange-secondary">Orange Secondary link</a>
                 </div>
                 <div class="p-2">
                     <a href="javascript: false" class="link link-yellow">Yellow link</a>
                 </div>
                 <div class="p-2">
                     <a href="javascript: false" class="link link-red">Red link</a>
-                </div>
-                <div class="p-2">
-                    <a href="javascript: false" class="link link-red-secondary">Red Secondary link</a>
                 </div>
             </div>
         </section>
@@ -345,7 +333,8 @@ const myHandler = (event) => {
                         <label for="textarea" class="form-label">
                             Textarea
                         </label>
-                        <textarea class="form-textarea" name="textarea" id="textarea" placeholder="my amazing textarea..."></textarea>
+                        <textarea class="form-textarea" name="textarea" id="textarea"
+                            placeholder="my amazing textarea..."></textarea>
                         <p class="text-red-secondary">Your content is just too awesome...</p>
                     </div>
                 </div>


### PR DESCRIPTION
I have removed the unstyled link examples. 💯 